### PR TITLE
[bugfix] Fix CoM velocity and acceleration update

### DIFF
--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1042,6 +1042,7 @@ void Robot::velW(const sva::MotionVecd & vel)
     module_.mbc.alpha[0][4] = vB.linear().y();
     module_.mbc.alpha[0][5] = vB.linear().z();
     rbd::forwardVelocity(mb(), module_.mbc);
+    com_->updateVelocity();
   }
   else
   {
@@ -1324,6 +1325,7 @@ void Robot::forwardVelocity()
 void Robot::forwardAcceleration()
 {
   updateFA();
+  com_->updateAcceleration();
 }
 
 tvm::VariablePtr Robot::qJoint(size_t jIdx)


### PR DESCRIPTION
When calling `Robot::velW(...)` or `Robot::accW(...)`, the floating base velocity/acceleration is properly updated, but the CoM velocity isn't. This is quite serious, as it means that the real robot's CoM velocity measurement is also wrong, which makes `LIPMStabilizer` fail ;)

This PR fixes the issue, and was tested on HRP4LIRMM.